### PR TITLE
Fix asset_events PK for partitioning and add missing indexes

### DIFF
--- a/deploy/sql/asset_events_v1_0.sql
+++ b/deploy/sql/asset_events_v1_0.sql
@@ -1,0 +1,89 @@
+-- AssetEvent v1.0 storage DDL (append-only)
+-- Aligns with schemas/v1.0/AssetEvent.json
+
+CREATE TABLE IF NOT EXISTS asset_events (
+    event_id UUID NOT NULL,
+    tenant_id TEXT NOT NULL,
+    project_id TEXT,
+    env TEXT,
+    asset_id UUID NOT NULL,
+    task_id UUID,
+    lease_id UUID,
+    correlation_id TEXT,
+    causation_id UUID,
+    event_type TEXT NOT NULL,
+    source TEXT,
+    severity TEXT CHECK (severity IN ('DEBUG', 'INFO', 'WARN', 'ERROR')),
+    old_status TEXT,
+    new_status TEXT,
+    message TEXT,
+    error_code TEXT,
+    error_message TEXT,
+    provider_status TEXT,
+    http_status INTEGER CHECK (http_status BETWEEN 100 AND 599),
+    latency_ms INTEGER CHECK (latency_ms >= 0),
+    retryable BOOLEAN,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    tags TEXT[],
+    context JSONB,
+    version INTEGER NOT NULL CHECK (version >= 1),
+    PRIMARY KEY (event_id, occurred_at)
+)
+PARTITION BY RANGE (occurred_at);
+
+-- Monthly partitions (extend with a rolling job as needed)
+-- Example: September and October 2024 partitions
+CREATE TABLE IF NOT EXISTS asset_events_2024_09
+    PARTITION OF asset_events
+    FOR VALUES FROM ('2024-09-01') TO ('2024-10-01');
+
+CREATE TABLE IF NOT EXISTS asset_events_2024_10
+    PARTITION OF asset_events
+    FOR VALUES FROM ('2024-10-01') TO ('2024-11-01');
+
+-- Indexes to support tenant and chain tracing
+CREATE INDEX IF NOT EXISTS idx_asset_events_tenant_occurred_at
+    ON asset_events (tenant_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_asset_events_correlation_occurred_at
+    ON asset_events (correlation_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_asset_events_causation_id
+    ON asset_events (causation_id);
+
+CREATE INDEX IF NOT EXISTS idx_asset_events_asset_id_occurred_at
+    ON asset_events (asset_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_asset_events_task_id
+    ON asset_events (task_id);
+
+-- Append-only guard: reject UPDATE/DELETE
+CREATE OR REPLACE FUNCTION asset_events_block_mutations()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'asset_events is append-only: % not allowed', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'asset_events_no_update'
+    ) THEN
+        CREATE TRIGGER asset_events_no_update
+            BEFORE UPDATE ON asset_events
+            FOR EACH ROW EXECUTE FUNCTION asset_events_block_mutations();
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'asset_events_no_delete'
+    ) THEN
+        CREATE TRIGGER asset_events_no_delete
+            BEFORE DELETE ON asset_events
+            FOR EACH ROW EXECUTE FUNCTION asset_events_block_mutations();
+    END IF;
+END;
+$$;

--- a/docs/guides/asset-event-storage.md
+++ b/docs/guides/asset-event-storage.md
@@ -1,0 +1,29 @@
+# AssetEvent 存储（v1.0)
+
+本文档给出与 [`schemas/v1.0/AssetEvent.json`](../../schemas/v1.0/AssetEvent.json) 对齐的数据库建模与迁移示例，遵循 Schema v1.0 的字段和约束。
+
+## 目标
+- 保持与 Schema 必填字段一致（`event_id`, `tenant_id`, `asset_id`, `event_type`, `occurred_at`, `recorded_at`, `version` 设为 NOT NULL）。
+- 追加写（Append-Only）：不允许 UPDATE/DELETE，所有历史均可重放。
+- 优化链路追踪：为 `tenant_id + occurred_at`、`correlation_id + occurred_at`、`causation_id` 建索引。
+- 支撑高写入：按月分区示例，可按租户或时间滚动扩展。
+
+## 示例 DDL / 迁移脚本
+迁移脚本位于 [`deploy/sql/asset_events_v1_0.sql`](../../deploy/sql/asset_events_v1_0.sql)，要点如下：
+
+- **字段对齐**：类型与 JSON Schema 对齐，`severity`、`http_status`、`latency_ms`、`version` 等都带校验。
+- **主键**：`event_id + occurred_at` 联合 PK，满足分区唯一约束要求并保持事件唯一性。
+- **组合索引**：覆盖租户时间序、资产画像（`asset_id + occurred_at`）、调用链（correlation）、因果链（causation）、任务归因（`task_id`）。
+- **追加写保护**：触发器阻止 UPDATE/DELETE，违反即抛错。
+- **分区示例**：默认按 `occurred_at` RANGE 分区，附带 2024-09/10 示例分区，可由运维任务滚动创建后续分区；若需租户分片，可改为 `PARTITION BY LIST (tenant_id)`。
+
+## 使用建议
+1. 在上线前执行脚本，或将其拆分成迁移管理工具的 step：
+   ```sql
+   \i deploy/sql/asset_events_v1_0.sql
+   ```
+2. 如果写入量高，建议提前创建未来 2~3 个月的分区，或用调度任务在月底自动生成下一月分区。
+3. 追加写策略与审计需求一致，如需数据修正，请采用“补偿事件”而非更新历史行。
+4. 若租户隔离需求更高，可改用 `PARTITION BY LIST (tenant_id)` 并按租户/月份组合创建分区，索引定义保持不变。
+
+> Schema 版本：v1.0（请在未来版本升级时同步更新本文档与 SQL 脚本）。


### PR DESCRIPTION
## Summary
- change asset_events primary key to include occurred_at for partition compatibility
- add asset_id and task_id indexes for asset timeline and task attribution queries
- document updated primary key and index coverage in storage guide

## Testing
- not run (SQL and documentation changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e0d5c440832a82ef36d39c3e84e2)