### PR TITLE
Add provider performance and error analytics views

### DIFF
--- a/deploy/sql/asset_events_v1_0.sql
+++ b/deploy/sql/asset_events_v1_0.sql
@@ -58,6 +58,142 @@ CREATE INDEX IF NOT EXISTS idx_asset_events_asset_id_occurred_at
 CREATE INDEX IF NOT EXISTS idx_asset_events_task_id
     ON asset_events (task_id);
 
+-- Weak foreign keys (NOT VALID + DEFERRABLE) to keep referential integrity with TaskOrder / Lease
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'task_orders'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'fk_asset_events_task'
+    ) THEN
+        ALTER TABLE asset_events
+            ADD CONSTRAINT fk_asset_events_task
+            FOREIGN KEY (task_id)
+            REFERENCES task_orders(task_id)
+            ON DELETE SET NULL
+            DEFERRABLE INITIALLY DEFERRED
+            NOT VALID; -- async VALIDATE in backfill job to avoid blocking ingest
+    END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'leases'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'fk_asset_events_lease'
+    ) THEN
+        ALTER TABLE asset_events
+            ADD CONSTRAINT fk_asset_events_lease
+            FOREIGN KEY (lease_id)
+            REFERENCES leases(lease_id)
+            ON DELETE SET NULL
+            DEFERRABLE INITIALLY DEFERRED
+            NOT VALID;
+    END IF;
+END;
+$$;
+
+-- Enriched trace view: joins TaskOrder / AssetSnapshot / LedgerEntry for auditing
+CREATE OR REPLACE VIEW asset_event_traces AS
+SELECT
+    ae.event_id,
+    ae.occurred_at,
+    ae.recorded_at,
+    ae.tenant_id,
+    ae.project_id,
+    ae.env,
+    ae.asset_id,
+    ae.task_id,
+    ae.lease_id,
+    ae.correlation_id,
+    ae.causation_id,
+    ae.event_type,
+    ae.severity,
+    ae.message,
+    ae.old_status AS event_old_status,
+    ae.new_status AS event_new_status,
+    ae.error_code,
+    ae.error_message,
+    ae.provider_status,
+    ae.http_status,
+    ae.latency_ms,
+    ae.tags,
+    ae.context,
+    todr.task_type,
+    todr.status AS task_status,
+    todr.priority AS task_priority,
+    todr.timeout_ms AS task_timeout_ms,
+    todr.task_version,
+    snap.snapshot_version,
+    snap.status AS current_asset_status,
+    snap.provider_id,
+    snap.sku_category,
+    le.ledger_entry_id,
+    le.direction AS ledger_direction,
+    le.category AS ledger_category,
+    le.amount AS ledger_amount,
+    le.currency AS ledger_currency
+FROM asset_events ae
+LEFT JOIN task_orders todr
+    ON todr.task_id = ae.task_id
+LEFT JOIN asset_snapshots snap
+    ON snap.asset_id = ae.asset_id
+LEFT JOIN ledger_entries le
+    ON le.task_id = ae.task_id
+    AND le.asset_id = ae.asset_id;
+
+-- Parameterized trace helper: filter by task_id or correlation_id, ordered by occurred_at
+CREATE OR REPLACE FUNCTION trace_asset_events(
+    p_task_id UUID DEFAULT NULL,
+    p_correlation_id TEXT DEFAULT NULL
+)
+RETURNS SETOF asset_event_traces
+LANGUAGE sql
+AS $$
+    SELECT *
+    FROM asset_event_traces
+    WHERE (p_task_id IS NULL OR task_id = p_task_id)
+      AND (p_correlation_id IS NULL OR correlation_id = p_correlation_id)
+    ORDER BY occurred_at;
+$$;
+
+-- Provider performance analytics (rolling 24h): success rate and latency by provider + SKU + error_code
+CREATE OR REPLACE VIEW view_provider_performance AS
+SELECT
+    snap.provider_id,
+    snap.sku_category,
+    ae.error_code,
+    COUNT(*) AS total_tasks,
+    COUNT(*) FILTER (WHERE ae.error_code IS NOT NULL OR ae.severity = 'ERROR') AS failure_count,
+    COUNT(*) FILTER (WHERE ae.error_code IS NULL AND ae.severity <> 'ERROR') AS success_count,
+    CASE WHEN COUNT(*) = 0 THEN 0 ELSE (COUNT(*) FILTER (WHERE ae.error_code IS NULL AND ae.severity <> 'ERROR'))::NUMERIC / COUNT(*) END AS success_rate,
+    AVG(ae.latency_ms)::NUMERIC AS avg_latency_ms
+FROM asset_events ae
+LEFT JOIN asset_snapshots snap
+    ON snap.asset_id = ae.asset_id
+WHERE ae.occurred_at >= now() - INTERVAL '24 hours'
+GROUP BY snap.provider_id, snap.sku_category, ae.error_code;
+
+-- Error distribution fingerprint: task type + error_code + http_status with impacted asset counts
+CREATE OR REPLACE VIEW view_error_patterns AS
+SELECT
+    COALESCE(todr.task_type, 'UNKNOWN') AS task_type,
+    ae.error_code,
+    ae.http_status,
+    COUNT(*) AS occurrence_count,
+    COUNT(DISTINCT ae.asset_id) AS affected_asset_count
+FROM asset_events ae
+LEFT JOIN task_orders todr
+    ON todr.task_id = ae.task_id
+WHERE ae.error_code IS NOT NULL OR ae.severity = 'ERROR'
+GROUP BY COALESCE(todr.task_type, 'UNKNOWN'), ae.error_code, ae.http_status;
+
 -- Append-only guard: reject UPDATE/DELETE
 CREATE OR REPLACE FUNCTION asset_events_block_mutations()
 RETURNS TRIGGER AS $$

--- a/docs/guides/asset-event-storage.md
+++ b/docs/guides/asset-event-storage.md
@@ -27,3 +27,72 @@
 4. 若租户隔离需求更高，可改用 `PARTITION BY LIST (tenant_id)` 并按租户/月份组合创建分区，索引定义保持不变。
 
 > Schema 版本：v1.0（请在未来版本升级时同步更新本文档与 SQL 脚本）。
+
+## 链路查询与审计视图
+- 在 `deploy/sql/asset_events_v1_0.sql` 中新增 `asset_event_traces` 视图以及 `trace_asset_events` 查询函数，用于把 AssetEvent 与 TaskOrder / AssetSnapshot / LedgerEntry 进行左连接并按时间轴返回。
+- 典型排障/审计用法：
+  ```sql
+  -- 按 task_id 获取事件序列
+  SELECT * FROM trace_asset_events('00000000-0000-0000-0000-000000000001');
+
+  -- 按 correlation_id 获取调用链
+  SELECT * FROM trace_asset_events(NULL, 'corr-123')
+  WHERE tenant_id = 'demo-tenant';
+
+  -- 直接使用视图并带其他过滤条件
+  SELECT *
+  FROM asset_event_traces
+  WHERE tenant_id = 'demo-tenant'
+    AND env = 'prod'
+    AND occurred_at >= now() - interval '1 day'
+  ORDER BY occurred_at;
+  ```
+> 提示：`asset_event_traces` 暴露 `event_old_status`/`event_new_status`（事件时上下文）与 `current_asset_status`（最新快照）两个维度，避免把“事后快照”误解为事件当时的状态。
+
+## 法医诊断视图（并发场景快速归因）
+在高并发/多 Worker 场景下，为避免导出 CSV 做透视表，新增两个聚合视图直接输出“谁表现差”“怎么死的”：
+
+### 供应商/品类绩效（view_provider_performance）
+按 `provider_id + sku_category + error_code` 聚合过去 24 小时的成功率和耗时，可直接找出劣质供应商或脆弱 SKU：
+
+```sql
+-- 找出成功率低于 80% 的供应商/品类
+SELECT *
+FROM view_provider_performance
+WHERE success_rate < 0.8
+ORDER BY success_rate ASC, avg_latency_ms DESC;
+
+-- 聚焦某个 provider 的耗时与错误分布
+SELECT sku_category, error_code, total_tasks, failure_count, success_rate, avg_latency_ms
+FROM view_provider_performance
+WHERE provider_id = 'provider-123'
+ORDER BY success_rate ASC;
+```
+
+### 失败指纹分布（view_error_patterns）
+按 `task_type + error_code + http_status` 聚合失败次数与受影响资产数，一眼看出是大规模封号（资产数多）还是逻辑错误：
+
+```sql
+-- 查看近 24 小时主要失败形态
+SELECT *
+FROM view_error_patterns
+ORDER BY occurrence_count DESC
+LIMIT 20;
+
+-- 检查单一错误是否集中在特定 task_type
+SELECT task_type, occurrence_count, affected_asset_count
+FROM view_error_patterns
+WHERE error_code = 'IP_BANNED'
+ORDER BY occurrence_count DESC;
+```
+
+## task_id / lease_id 的外键或弱引用
+- 同步约束：脚本使用 `NOT VALID + DEFERRABLE` 外键（`fk_asset_events_task`、`fk_asset_events_lease`）指向 `task_orders(task_id)`、`leases(lease_id)`，默认 `ON DELETE SET NULL` 避免删除上游记录时阻塞事件表。该设计可在写入高峰时先挂载约束、再用后台作业 `VALIDATE CONSTRAINT` 完成校验。
+- 异步校验（跨库或历史存量）：当 TaskOrder/Lease 不与 AssetEvent 同库时，可保留弱引用（约束存在但暂不 VALIDATE），并用夜间/低峰任务执行：
+  ```sql
+  -- 异步校验并回填坏数据
+  ALTER TABLE asset_events VALIDATE CONSTRAINT fk_asset_events_task;
+  ALTER TABLE asset_events VALIDATE CONSTRAINT fk_asset_events_lease;
+  ```
+  对于校验失败的行，可按 `task_id` / `lease_id` 进行修复或补全数据后再次 VALIDATE；若无法修复，可把引用置空并记录补偿事件。
+- 结合链路追踪：上述视图/函数允许在审计时同时观察 Task/Lease、资产画像与资金流水，便于快速定位“谁触发”“用了哪个 Lease”“产生了哪些账务影响”。


### PR DESCRIPTION
## Summary
- clarify asset_event_traces output by surfacing event status fields alongside current asset snapshot columns
- add view_provider_performance and view_error_patterns aggregation views for 24h provider scoring and error fingerprinting
- document forensic query examples for the new analytics and snapshot context caveats

## Testing
- not run (SQL/doc changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69324a75e2ec832a9e75070e734b70cf)